### PR TITLE
変数名をcamelCaseに統一

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "camelcase": "warn"
   }
 }

--- a/js/mod/config.js
+++ b/js/mod/config.js
@@ -1,3 +1,3 @@
-var maginai_config = {
+var maginaiConfig = {
   logLevel: 'info',
 };

--- a/js/mod/modules/logging.js
+++ b/js/mod/modules/logging.js
@@ -5,7 +5,7 @@ function initLog() {
   prefix.reg(logging);
 
   try {
-    logging.setLevel(maginai_config['logLevel']);
+    logging.setLevel(maginaiConfig['logLevel']);
   } catch (e) {
     console.error(
       'Configの読み込みに失敗しました。config.jsが存在しているか、内容が正しいか確認してください',

--- a/js/mod/modules/maginai.js
+++ b/js/mod/modules/maginai.js
@@ -199,7 +199,7 @@ export class Maginai {
      * というサイクルでPostprocessを実行する
      * @type {Promise<any>}
      */
-    this.current_mod_postprocess = null;
+    this.currentModPostprocess = null;
 
     // 以下サブモジュールの公開
     /**
@@ -423,7 +423,7 @@ export class Maginai {
    * @param {Promise<any>} promise
    */
   setModPostprocess(promise) {
-    this.current_mod_postprocess = Promise.resolve(promise);
+    this.currentModPostprocess = Promise.resolve(promise);
   }
 
   /**
@@ -433,8 +433,8 @@ export class Maginai {
    * @return {Promise<any>} setされていたPromise
    */
   popModPostprocess() {
-    const rtn = this.current_mod_postprocess ?? Promise.resolve();
-    this.current_mod_postprocess = undefined;
+    const rtn = this.currentModPostprocess ?? Promise.resolve();
+    this.currentModPostprocess = undefined;
     return rtn;
   }
 


### PR DESCRIPTION
変数名をcamelCaseに統一して.eslintrcにcamelcaseのルールを追加しました。