### PR TITLE
fix: Windowsでnpm installに失敗する

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -49,7 +49,7 @@ jobs:
               }
             }
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:dist
       - uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{steps.package-version.outputs.PACKAGE_VERSION}}

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -85,14 +85,20 @@ vitestを使用
 
 ### Scripts
 
-#### 配布zipと型定義パッケージのビルド
+#### 型定義パッケージのビルド
 ```
-npm run build
+npm run build:package
+```
+
+`libs/`下にMOD開発用パッケージ用の型定義出力  
+
+#### 配布zipのビルド
+```
+npm run build:dist
 ```
 
 `dist/`下に配布zip出力  
 `dist/maginai/`フォルダがzipの内容  
-`libs/`下にMOD開発用パッケージ用の型定義出力  
 
 #### ドキュメント
 ```

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "./*": "./lib/modules/*"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "npm run build:package",
     "dev": "vite build",
-    "build": "npm run build:package && npm run build:dist",
     "build:dist": "rimraf dist && npm run dev && node ./tools/release.js",
     "build:package": "rimraf lib && tsc",
     "build:docs": "typedoc",


### PR DESCRIPTION
fix #20  

build:dist emits error on Windows because it lacks zip command, and npm prepare ran build:dist.
Now npm prepare runs only build:package.