### PR TITLE
fix: CIにnpm publishの認証を設定する

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,5 +12,8 @@ jobs:
       - uses: actions/setup-node@v3.8.1
         with:
           node-version: 18.x
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
fix #23  