### PR TITLE
typedoc-plugin-missing-exportsの更新

### DIFF
--- a/MOD_DEVELOP.md
+++ b/MOD_DEVELOP.md
@@ -93,7 +93,7 @@ maginai.events.gameLoadFinished.addHandler(() => {
 ```
 
 すべてのイベントは以下に掲載されています。  
-https://spoonail-iroiro.github.io/maginai/classes/_internal_.MaginaiEvents.html
+https://spoonail-iroiro.github.io/maginai/classes/MaginaiEvents.html
 
 ## はじめての人向け
 まだModとか作ってないよという方向けの説明です。  
@@ -186,7 +186,7 @@ https://github.com/Spoonail-Iroiro/maginai-buildsample
 
 # `maginai` API
 `maginai`が公開するすべての機能のドキュメントは以下で公開されています。  
-[maginai APIドキュメント](https://spoonail-iroiro.github.io/maginai/classes/_internal_.Maginai.html)  
+[maginai APIドキュメント](https://spoonail-iroiro.github.io/maginai/classes/Maginai.html)  
 ※`Internal`マークがついてるものは内部用でModからの利用は想定されていません  
 
 `maginai`は実際には`Maginai`クラスインスタンスですので`Maginai`クラス下に公開されているものを使用できます。  
@@ -210,7 +210,7 @@ https://github.com/Spoonail-Iroiro/maginai-buildsample
 いくつかの例ではわかりやすさのため`console.log`でログ出力していますが、実際のModコードでは非推奨です。  
 かわりに以下に掲載の例の通り、`Logger`オブジェクトを取得してログ出力を行ってください。  
 
-[https://spoonail-iroiro.github.io/maginai/classes/_internal_.Maginai.html#logging](https://spoonail-iroiro.github.io/maginai/classes/_internal_.Maginai.html#logging)
+[https://spoonail-iroiro.github.io/maginai/classes/Maginai.html#logging](https://spoonail-iroiro.github.io/maginai/classes/Maginai.html#logging)
 
 loggerを使うことでどのModからのログなのかわかりやすく、ユーザーが表示レベル等を制御できます。  
 
@@ -224,7 +224,7 @@ IIFEでなくグローバルに書いた場合、たとえば同じ`const hoge`�
 ## `tGameMain`クラスはそのまま使用できない
 `tGameMain`クラスはゲーム初期化を遅らせるためダミーになっており直接使用できません。  
 メソッドのパッチなどでアクセスしたい場合は以下に記載の通りとしてください。  
-https://spoonail-iroiro.github.io/maginai/classes/_internal_.Maginai.html#origtGameMain
+https://spoonail-iroiro.github.io/maginai/classes/Maginai.html#origtGameMain
 
 ## Mod名は重複しない特徴的なものを付けるようにする
 Modはフォルダで導入するため同じMod名で別のModを入れることはできません。  

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "maginai-game-types": "^2.1.0",
         "rimraf": "^5.0.5",
         "typedoc": "^0.25.1",
-        "typedoc-plugin-missing-exports": "^2.1.0",
+        "typedoc-plugin-missing-exports": "^2.2.0",
         "typescript": "^5.2.2",
         "vite": "^4.4.5",
         "vitest": "^0.34.4"
@@ -2474,9 +2474,9 @@
       }
     },
     "node_modules/typedoc-plugin-missing-exports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.1.0.tgz",
-      "integrity": "sha512-+1DhqZCEu7Vu5APnrqpPwl31D+hXpt1fV0Le9ycCRL1eLVdatdl6KVt4SEVwPxnEpKwgOn2dNX6I9+0F1aO2aA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.2.0.tgz",
+      "integrity": "sha512-2+XR1IcyQ5UwXZVJe9NE6HrLmNufT9i5OwoIuuj79VxuA3eYq+Y6itS9rnNV1D7UeQnUSH8kISYD73gHE5zw+w==",
       "dev": true,
       "peerDependencies": {
         "typedoc": "0.24.x || 0.25.x"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "maginai-game-types": "^2.1.0",
     "rimraf": "^5.0.5",
     "typedoc": "^0.25.1",
-    "typedoc-plugin-missing-exports": "^2.1.0",
+    "typedoc-plugin-missing-exports": "^2.2.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.5",
     "vitest": "^0.34.4"

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": [
-    //"./lib/loader.d.ts"
-    "./js/mod/loader.js"
-    //"./lib/*.d.ts",
-    //"./lib/**/*.d.ts"
+    "./js/mod/modules/maginai.js"
   ],
   "includeVersion": true,
   "markedOptions": {
@@ -13,6 +10,7 @@
   "plugin": [
     "typedoc-plugin-missing-exports",
   ],
+  "placeInternalsInOwningModule": true,
   "logLevel": "Verbose",
   "tsconfig": "./tsconfig.typedoc.json",
   "visibilityFilters": {


### PR DESCRIPTION
typedoc-plugin-missing-exportsを更新しました。\<internal\>をなくせるようになりました。

![Sprite-0001](https://github.com/Spoonail-Iroiro/maginai/assets/96245674/a021b11e-5a32-481a-a36f-bc93e5f8dfd2)
